### PR TITLE
fix warnings/errors when WP_DEBUG is enabled

### DIFF
--- a/themes/OneMozilla/colors/obsidian/obsidian-editor-style.css
+++ b/themes/OneMozilla/colors/obsidian/obsidian-editor-style.css
@@ -2,40 +2,40 @@
 /* Regular */
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
@@ -43,30 +43,30 @@
 /* Light */
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }

--- a/themes/OneMozilla/colors/sand/sand-editor-style.css
+++ b/themes/OneMozilla/colors/sand/sand-editor-style.css
@@ -2,40 +2,40 @@
 /* Regular */
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
@@ -43,30 +43,30 @@
 /* Light */
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }

--- a/themes/OneMozilla/colors/sky/sky-editor-style.css
+++ b/themes/OneMozilla/colors/sky/sky-editor-style.css
@@ -2,40 +2,40 @@
 /* Regular */
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
@@ -43,30 +43,30 @@
 /* Light */
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }

--- a/themes/OneMozilla/colors/stone/stone-editor-style.css
+++ b/themes/OneMozilla/colors/stone/stone-editor-style.css
@@ -2,40 +2,40 @@
 /* Regular */
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
@@ -43,30 +43,30 @@
 /* Light */
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }

--- a/themes/OneMozilla/comments.php
+++ b/themes/OneMozilla/comments.php
@@ -63,7 +63,7 @@
         <p id="cancel-comment-reply"><?php cancel_comment_reply_link('Cancel Reply'); ?></p>
         <ol>
         <?php if ( $user_ID ) : ?>
-          <li class="self"><?php printf( __( 'You are logged in as <a href="%1$s">%2$s</a>. <a class="logout" href="%3$s">Log out?</a>', 'onemozilla' ), admin_url( 'profile.php' ), esc_html($user_identity), wp_logout_url( apply_filters( 'the_permalink', get_permalink( $post_id ) ) ) ); ?></li>
+          <li class="self"><?php printf( __( 'You are logged in as <a href="%1$s">%2$s</a>. <a class="logout" href="%3$s">Log out?</a>', 'onemozilla' ), admin_url( 'profile.php' ), esc_html($user_identity), wp_logout_url( apply_filters( 'the_permalink', get_permalink() ) ) ); ?></li>
         <?php else : ?>
           <li id="cmt-name">
             <label for="author"><?php _e('Name', 'onemozilla'); ?> <?php if ($req) : ?><span class="note"><?php _e('(required)', 'onemozilla'); ?></span><?php endif; ?></label>

--- a/themes/OneMozilla/css/login.css
+++ b/themes/OneMozilla/css/login.css
@@ -1,9 +1,9 @@
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }

--- a/themes/OneMozilla/css/print.css
+++ b/themes/OneMozilla/css/print.css
@@ -5,30 +5,30 @@ header, hgroup, nav, section, article, aside, footer { display: block; }
 /* Light */
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }

--- a/themes/OneMozilla/footer.php
+++ b/themes/OneMozilla/footer.php
@@ -26,7 +26,7 @@
   </div>
 </footer>
 
-<script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
+<script src="https://mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
 
 <?php wp_footer(); ?>
 

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -52,7 +52,17 @@ function onemozilla_setup() {
 
   // Add a way for the custom header to be styled in the admin panel that controls
   // custom headers. See onemozilla_admin_header_style(), below.
-  add_custom_image_header( 'onemozilla_header_style', 'onemozilla_admin_header_style', 'onemozilla_admin_header_image' );
+  global $wp_version;
+  if ( version_compare( $wp_version, '3.4', '>=' ) ) {
+    $defaults = array(
+      'wp-head-callback' => 'onemozilla_header_style',
+      'admin-head-callback' => 'onemozilla_admin_header_style',
+      'admin-preview-callback' => 'onemozilla_admin_header_image',
+    );
+    add_theme_support( 'custom-header', $defaults );
+  } else {
+    add_custom_image_header( 'onemozilla_header_style', 'onemozilla_admin_header_style', 'onemozilla_admin_header_image' );
+  }
 
   // Disable the header text and color options
   define( 'NO_HEADER_TEXT', true );

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -84,15 +84,15 @@ function onemozilla_setup() {
   $options = get_option( 'onemozilla_theme_options' );
 
   // Stash the values in variables
-  if (array_key_exists('color_scheme', $options)) {
+  if (isset($options['color_scheme'])) {
     $color_scheme = $options['color_scheme'];
   }
 
-  if (array_key_exists('share_posts', $options)) {
+  if (isset($options['share_posts'])) {
     $share_posts = $options['share_posts'];
   }
 
-  if (array_key_exists('hide_author', $options)) {
+  if (isset($options['hide_author'])) {
     $hide_authors = $options['hide_author'];
   }
 

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -381,7 +381,7 @@ add_action( 'widgets_init', 'onemozilla_remove_recent_comments_style' );
 function fc_password_form() {
   global $post;
   $label = 'pwbox-'.(empty($post->ID) ? rand() : $post->ID);
-  $output = '<form class="pwform" action="' . get_option('siteurl') . '/wp-pass.php" method="post">
+  $output = '<form class="pwform" action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" method="post">
             <p>'.__("This post is password protected. To view it, please enter the password.", "onemozilla").'</p>
             <ol><li><label for="'.$label.'">'.__("Password", "onemozilla").'</label><input name="post_password" id="'.$label.'" type="password" size="20" /></li><li><button type="submit" name="Submit">'.esc_attr__("Submit").'</button></li></ol>
             </form>';

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -74,18 +74,26 @@ function onemozilla_setup() {
   $options = get_option( 'onemozilla_theme_options' );
 
   // Stash the values in variables
-  $color_scheme = $options['color_scheme'];
-  $share_posts = $options['share_posts'];
-  $hide_authors = $options['hide_author'];
+  if (array_key_exists('color_scheme', $options)) {
+    $color_scheme = $options['color_scheme'];
+  }
 
-  if ( $options['share_posts'] && (get_option('onemozilla_share_posts') == null) ) {
+  if (array_key_exists('share_posts', $options)) {
+    $share_posts = $options['share_posts'];
+  }
+
+  if (array_key_exists('hide_author', $options)) {
+    $hide_authors = $options['hide_author'];
+  }
+
+  if ( isset($share_posts) && (get_option('onemozilla_share_posts') == null) ) {
     update_option('onemozilla_share_posts', $share_posts);
   }
-  if ( $options['hide_author'] && (get_option('onemozilla_hide_authors') == null) ) {
+  if ( isset($hide_authors) && (get_option('onemozilla_hide_authors') == null) ) {
     update_option('onemozilla_hide_authors', $hide_authors);
   }
   // Remove the old values from theme_options, we're only keeping the color scheme (if set)
-  if ( $options['color_scheme'] ) {
+  if ( isset($color_scheme) ) {
     update_option('onemozilla_theme_options', array('color_scheme' => $color_scheme));
   }
   else {

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -461,7 +461,9 @@ add_action('admin_init', 'register_fc_featuredpost', 1);
 
 function save_fc_featuredpost() {
   global $post;
-  update_post_meta($post->ID, "_fc_featuredpost", $_POST["_fc_featuredpost"]);
+  if (isset($_POST["_fc_featuredpost"])) {
+    update_post_meta($post->ID, "_fc_featuredpost", $_POST["_fc_featuredpost"]);
+  }  
 }
 add_action('save_post', 'save_fc_featuredpost');
 

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -175,6 +175,7 @@ function onemozilla_settings_field_hide_authors() { ?>
  * Adds classes to the array of post classes. We'll use these as style hooks for post headers.
  */
 function onemozilla_post_classes( $classes ) {
+  global $post;
   $comment_count = get_comments_number($post->ID);
 
   if ( get_option('onemozilla_hide_authors') != 1 ) {

--- a/themes/OneMozilla/header.php
+++ b/themes/OneMozilla/header.php
@@ -58,7 +58,7 @@
   <?php wp_head(); ?>
 </head>
 
-<body <?php body_class($theme_options[color_scheme]); ?>>
+<body <?php body_class($theme_options['color_scheme']); ?>>
 <div id="page"><div class="wrap">
   <nav id="nav-access">
     <ul role="navigation">

--- a/themes/OneMozilla/header.php
+++ b/themes/OneMozilla/header.php
@@ -35,7 +35,7 @@
   <link rel="stylesheet" type="text/css" media="all" href="<?php echo get_template_directory_uri(); ?>/css/socialshare.css">
   <?php endif; ?>
   <link rel="stylesheet" type="text/css" media="screen,projection" href="<?php bloginfo('stylesheet_url'); ?>">
-  <link rel="stylesheet" type="text/css" media="all" href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css">
+  <link rel="stylesheet" type="text/css" media="all" href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css">
   <link rel="stylesheet" type="text/css" media="print" href="<?php echo get_template_directory_uri(); ?>/css/print.css">
   <!--[if lte IE 7]><link rel="stylesheet" type="text/css" media="all" href="<?php echo get_template_directory_uri(); ?>/css/ie7.css"><![endif]-->
 

--- a/themes/OneMozilla/inc/theme-options.php
+++ b/themes/OneMozilla/inc/theme-options.php
@@ -195,7 +195,7 @@ function onemozilla_theme_options_render_page() {
   ?>
   <div class="wrap">
     <?php screen_icon(); ?>
-    <h2><?php printf( __( '%s Theme Options', 'onemozilla' ), get_current_theme() ); ?></h2>
+    <h2><?php printf( __( '%s Theme Options', 'onemozilla' ), wp_get_theme() ); ?></h2>
     <?php settings_errors(); ?>
 
     <form method="post" action="options.php">

--- a/themes/OneMozilla/style.css
+++ b/themes/OneMozilla/style.css
@@ -23,40 +23,40 @@ Tags: two-columns, right-sidebar, fixed-width, responsive, adaptive-layout, cust
 /* Regular */
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Italic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Semibold-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-SemiboldItalic-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: italic;
 }
@@ -64,30 +64,30 @@ Tags: two-columns, right-sidebar, fixed-width, responsive, adaptive-layout, cust
 /* Light */
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Light-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-LightItalic-webfont.ttf") format("truetype");
   font-weight: normal;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Open Sans Light";
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot");
-  src: url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
-       url("//www.mozilla.org/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot");
+  src: url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.eot?#iefix") format("embedded-opentype"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.woff") format("woff"),
+       url("https://mozorg.cdn.mozilla.net/media/fonts/OpenSans-Regular-webfont.ttf") format("truetype");
   font-weight: bold;
   font-style: normal;
 }


### PR DESCRIPTION
I went through and fixed every warning/error that came up for the One Mozilla theme while WP_DEBUG was enabled. This will ensure future compatibility, etc.