### PR TITLE
no background-color for img in obsidian

### DIFF
--- a/themes/OneMozilla/colors/obsidian/obsidian.css
+++ b/themes/OneMozilla/colors/obsidian/obsidian.css
@@ -40,7 +40,6 @@ h1, h2, h3, h4, h5, h6 {
 }
 .entry-content img,
 .entry-summary img {
-  background-color: #2e475a;
   border-color: #2e475a;
 }
 


### PR DESCRIPTION
The background-color for images in entry-content in obsidian causes some ugliness when there's transparency...see here with the async logo: https://bugzilla.mofostaging.net/paid-support/

Also, the border color doesn't really do much of anything, given that there's no border size, so you might want to consider getting rid of that too.

Thanks!