### PR TITLE
Filter shortcodes in fc_meta_desc()

### DIFF
--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -231,6 +231,7 @@ function fc_meta_desc() {
     } else {
       $text = $post->post_content;
     }
+    $text = do_shortcode($text);
     $text = str_replace(array("\r\n", "\r", "\n", "  "), " ", $text);
     $text = str_replace(array("\""), "", $text);
     $text = trim(strip_tags($text));


### PR DESCRIPTION
Filter shortcodes in `fc_meta_desc()`, so their output is shown in instead of the shortcode itself. You can see the current result without shortcode filtered e.g. in [Google results for mozilla.cz](https://www.google.cz/search?q=mozilla.cz&ie=utf-8&oe=utf-8) (under *Stáhnout Firefox* headline).