### PR TITLE
Integrate support for Discourse comments

### DIFF
--- a/themes/OneMozilla/comments.php
+++ b/themes/OneMozilla/comments.php
@@ -31,7 +31,7 @@
   </header>
 
 <?php if ( have_comments() ) : // If there are comments ?>
-  <ol id="comment-list" class="hfeed <?php if (get_option('show_avatars')) echo 'av'; // provides a style hook when avatars are enabled ?>">
+  <ol id="comment-list" class="comment-list hfeed <?php if (get_option('show_avatars')) echo 'av'; // provides a style hook when avatars are enabled ?>">
   <?php wp_list_comments('type=all&style=ol&callback=onemozilla_comment'); // Comment template is in functions.php ?>
   </ol>
 

--- a/themes/OneMozilla/content-single.php
+++ b/themes/OneMozilla/content-single.php
@@ -2,20 +2,26 @@
   <header class="entry-header">
     <h1 class="entry-title"><?php the_title(); ?></h1>
 
-  <?php if ( get_option('onemozilla_hide_authors') != 1 ) : ?>
-    <address class="vcard">
-      <cite class="author fn">
-        <a class="url" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) ?>" title="<?php printf( esc_attr__( 'See all posts by %1$s', 'onemozilla'), get_the_author() ); ?>">
-          <?php esc_html(the_author()); ?> <?php echo get_avatar(get_the_author_meta('user_email'), 24) ?>
-        </a>
-      </cite>
-    </address>
-  <?php endif; ?>
+<?php if ( (get_option('onemozilla_hide_authors') != 1) || comments_open() || get_comments_number() ) : ?>
+    <div class="entry-info">
 
-  <?php $comment_count = get_comments_number($post->ID);
-  if ( comments_open() || pings_open() || ($comment_count > 0) ) : ?>
-    <p class="entry-comments"><a href="<?php comments_link() ?>" title="<?php if($comment_count > 0) { printf(_n( '1 response', '%d responses', $comment_count, 'onemozilla'), $comment_count); } else { _e('No responses yet', 'onemozilla'); } ?>"><?php if ($comment_count > 999) : comments_number('0','1','1000+'); else : comments_number('0','1','%'); endif; ?></a></p>
-  <?php endif; ?>
+    <?php if ( get_option('onemozilla_hide_authors') != 1 ) : ?>
+      <address class="vcard">
+        <cite class="author fn">
+          <a class="url" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) ?>" title="<?php printf( esc_attr__( 'See all posts by %1$s', 'onemozilla'), get_the_author() ); ?>">
+            <?php esc_html(the_author()); ?> <?php echo get_avatar(get_the_author_meta('user_email'), 24) ?>
+          </a>
+        </cite>
+      </address>
+    <?php endif; ?>
+
+    <?php if ( comments_open() || get_comments_number() ) : ?>
+      <p class="entry-comments">
+        <?php comments_popup_link( __( 'No responses yet', 'onemozilla' ), __( '1 response', 'onemozilla' ), __( '% responses', 'onemozilla' ) ); ?>
+      </p>
+    <?php endif; ?>
+  </div>
+<?php endif; ?>
 
   <?php if ( 'post' == get_post_type() ) : // No posted date for Pages ?>
     <p class="entry-posted">

--- a/themes/OneMozilla/content-summary.php
+++ b/themes/OneMozilla/content-summary.php
@@ -22,6 +22,8 @@
       </p>
     <?php endif; ?>
 
+  <?php if ( (get_option('onemozilla_hide_authors') != 1) || comments_open() || get_comments_number() ) : ?>
+    <div class="entry-info">
     <?php if ( get_option('onemozilla_hide_authors') != 1 ) : ?>
       <address class="vcard">
         <cite class="author fn">
@@ -32,15 +34,14 @@
       </address>
     <?php endif; ?>
 
-    <?php $comment_count = get_comments_number($post->ID);
-    if ( comments_open() || pings_open() || ($comment_count > 0) ) : ?>
+    <?php if ( comments_open() || get_comments_number() ) : ?>
       <p class="entry-comments">
-        <a href="<?php comments_link() ?>" title="<?php if($comment_count > 0) { printf( _n( '1 response', '%d responses', $comment_count, 'onemozilla'), $comment_count ); } else { _e('No responses yet', 'onemozilla'); } ?>">
-          <?php if ($comment_count > 999) : comments_number('0','1','1000+'); else : comments_number('0','1','%'); endif; ?>
-        </a>
+        <?php comments_popup_link( __( 'No responses yet', 'onemozilla' ), __( '1 response', 'onemozilla' ), __( '% responses', 'onemozilla' ) ); ?>
       </p>
     <?php endif; ?>
     <?php edit_post_link( __( 'Edit Post', 'onemozilla' ), '<p class="edit">', '</p>' ); ?>
+    </div>
+  <?php endif; ?>
   </header>
 
   <div class="entry-summary">

--- a/themes/OneMozilla/content.php
+++ b/themes/OneMozilla/content.php
@@ -22,6 +22,8 @@
       </p>
     <?php endif; ?>
 
+  <?php if ( (get_option('onemozilla_hide_authors') != 1) || comments_open() || get_comments_number() ) : ?>
+    <div class="entry-info">
     <?php if ( get_option('onemozilla_hide_authors') != 1 ) : ?>
       <address class="vcard">
         <cite class="author fn">
@@ -32,15 +34,14 @@
       </address>
     <?php endif; ?>
 
-    <?php $comment_count = get_comments_number($post->ID);
-    if ( comments_open() || pings_open() || ($comment_count > 0) ) : ?>
+    <?php if ( comments_open() || get_comments_number() ) : ?>
       <p class="entry-comments">
-        <a href="<?php comments_link() ?>" title="<?php if($comment_count > 0) { printf( _n( '1 response', '%d responses', $comment_count, 'onemozilla'), $comment_count ); } else { _e('No responses yet', 'onemozilla'); } ?>">
-          <?php if ($comment_count > 999) : comments_number('0','1','1000+'); else : comments_number('0','1','%'); endif; ?>
-        </a>
+        <?php comments_popup_link( __( 'No responses yet', 'onemozilla' ), __( '1 response', 'onemozilla' ), __( '% responses', 'onemozilla' ) ); ?>
       </p>
     <?php endif; ?>
-    <?php edit_post_link( __( 'Edit Post', 'onemozilla' ), '<p class="edit">', '</p>' ); ?>
+  </div>
+  <?php endif; ?>
+  <?php edit_post_link( __( 'Edit Post', 'onemozilla' ), '<p class="edit">', '</p>' ); ?>
   </header>
 
   <div class="entry-content">

--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -692,7 +692,7 @@ function onemozilla_comment($comment, $args, $depth) {
     <?php else : // author has no link ?>
       <h3 class="entry-title vcard">
         <cite class="author fn"><?php esc_html(comment_author()); ?></cite>
-        <?php if (function_exists('get_avatar')) : echo ('<span class="photo">'.get_avatar( $comment, 48 ).'</span>'); endif; ?>
+        <?php if (function_exists('get_avatar')) : echo ('<span class="photo">'.get_avatar( $comment, 64 ).'</span>'); endif; ?>
         <span class="comment-meta"><?php _e('wrote on', 'onemozilla'); ?>
         <a href="<?php echo htmlspecialchars( get_comment_link( $comment->comment_ID ) ); ?>" rel="bookmark" title="<?php _e('Permanent link to this comment by ','onemozilla'); comment_author(); ?>">
         <time class="published" datetime="<?php comment_date('Y-m-d'); ?>" title="<?php comment_date('Y-m-d'); ?>">

--- a/themes/OneMozilla/languages/onemozilla.pot
+++ b/themes/OneMozilla/languages/onemozilla.pot
@@ -1,7 +1,8 @@
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: One Mozilla 1.4\n"
-"POT-Creation-Date: 2015-03-19 13:21-0800\n"
+"POT-Creation-Date: 2016-05-11 10:56-0700\n"
 "PO-Revision-Date: 2015-03-19 13:21-0800\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -9,7 +10,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.7.5\n"
+"X-Generator: Poedit 1.8.7\n"
 "X-Poedit-Basepath: .\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -46,8 +47,8 @@ msgstr ""
 msgid "Posts tagged with “%s”"
 msgstr ""
 
-#: ../archive.php:16 ../archive.php:17 ../archive.php:18 ../header.php:50
-#: ../header.php:51 ../header.php:52
+#: ../archive.php:16 ../archive.php:17 ../archive.php:18 ../header.php:61
+#: ../header.php:62 ../header.php:63
 #, php-format
 msgid "Posts from %s"
 msgstr ""
@@ -93,8 +94,16 @@ msgid ""
 "This post is password protected. Enter the password to view any comments."
 msgstr ""
 
-#: ../comments.php:29 ../content-single.php:17 ../content-summary.php:38
-#: ../content.php:38
+#: ../comments.php:29 ../content-single.php:20 ../content-summary.php:39
+#: ../content.php:39
+#, php-format
+msgid "1 response"
+msgid_plural "%d responses"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../comments.php:29 ../content-single.php:20 ../content-summary.php:39
+#: ../content.php:39
 msgid "No responses yet"
 msgstr ""
 
@@ -193,49 +202,46 @@ msgstr ""
 msgid "Edit Page"
 msgstr ""
 
-#: ../content-page.php:14 ../content-single.php:47 ../content.php:50
+#: ../content-page.php:14 ../content-single.php:53 ../content.php:51
 #: ../image.php:41
 msgid "Pages:"
 msgstr ""
 
-#: ../content-single.php:8 ../content-summary.php:28 ../content.php:28
+#: ../content-single.php:11 ../content-summary.php:30 ../content.php:30
 #, php-format
 msgid "See all posts by %1$s"
 msgstr ""
 
-#: ../content-single.php:17 ../content-summary.php:38 ../content.php:38
-#, php-format
-msgid "1 response"
-msgid_plural "%d responses"
-msgstr[0] ""
-msgstr[1] ""
+#: ../content-single.php:20 ../content-summary.php:39 ../content.php:39
+msgid "% responses"
+msgstr ""
 
-#: ../content-single.php:23 ../content-single.php:29 ../content-summary.php:12
+#: ../content-single.php:29 ../content-single.php:35 ../content-summary.php:12
 #: ../content-summary.php:18 ../content.php:12 ../content.php:18
 #, php-format
 msgid "See all posts from %s"
 msgstr ""
 
-#: ../content-single.php:41 ../content-summary.php:43 ../content.php:43
+#: ../content-single.php:47 ../content-summary.php:42 ../content.php:44
 msgid "Edit Post"
 msgstr ""
 
-#: ../content-single.php:53 ../content-summary.php:54 ../content.php:56
+#: ../content-single.php:59 ../content-summary.php:55 ../content.php:57
 msgid "Tags"
 msgstr ""
 
-#: ../content-single.php:55 ../content-summary.php:56 ../content.php:58
+#: ../content-single.php:61 ../content-summary.php:57 ../content.php:59
 #: ../sidebar.php:41
 msgid "Categories"
 msgstr ""
 
-#: ../content-summary.php:4 ../content.php:4 ../functions.php:754
+#: ../content-summary.php:4 ../content.php:4 ../functions.php:762
 #: ../index.php:21
 #, php-format
 msgid "Permanent link to “%s”"
 msgstr ""
 
-#: ../content.php:49
+#: ../content.php:50
 msgid "Continue reading &hellip;"
 msgstr ""
 
@@ -276,131 +282,131 @@ msgstr ""
 msgid "Primary Menu"
 msgstr ""
 
-#: ../functions.php:78
+#: ../functions.php:70
 msgid "Firefox Logo"
 msgstr ""
 
-#: ../functions.php:131
+#: ../functions.php:138
 msgid "Social sharing"
 msgstr ""
 
-#: ../functions.php:143 ../functions.php:175
+#: ../functions.php:150 ../functions.php:182
 msgid "Hide post authors"
 msgstr ""
 
-#: ../functions.php:159
+#: ../functions.php:166
 msgid "Add social sharing buttons to posts and pages"
 msgstr ""
 
-#: ../functions.php:161
+#: ../functions.php:168
 msgid "Adds buttons for Facebook, Twitter, and Google+."
 msgstr ""
 
-#: ../functions.php:177
+#: ../functions.php:184
 msgid "This removes the author byline and author bio from individual posts."
 msgstr ""
 
-#: ../functions.php:302
+#: ../functions.php:310
 #, php-format
 msgid "Page %s"
 msgstr ""
 
-#: ../functions.php:359
+#: ../functions.php:367
 msgid ""
 "Sorry, you appear to be a spamming robot because you filled in the hidden "
 "spam trap field. To show you are not a spammer, submit your comment again "
 "and leave the field blank."
 msgstr ""
 
-#: ../functions.php:385
+#: ../functions.php:393
 msgid "This post is password protected. To view it, please enter the password."
 msgstr ""
 
-#: ../functions.php:386
+#: ../functions.php:394
 msgid "Password"
 msgstr ""
 
-#: ../functions.php:386
+#: ../functions.php:394
 msgid "Submit"
 msgstr ""
 
-#: ../functions.php:453
+#: ../functions.php:461
 msgid "Make this a featured post?"
 msgstr ""
 
-#: ../functions.php:459
+#: ../functions.php:467
 msgid "Featured Post"
 msgstr ""
 
-#: ../functions.php:504
+#: ../functions.php:512
 msgid "Continue reading"
 msgstr ""
 
-#: ../functions.php:551
+#: ../functions.php:559
 msgid "Sidebar"
 msgstr ""
 
-#: ../functions.php:652
+#: ../functions.php:660
 msgid "Trackback from "
 msgstr ""
 
-#: ../functions.php:654 ../functions.php:663
+#: ../functions.php:662 ../functions.php:671
 msgid "on"
 msgstr ""
 
-#: ../functions.php:655 ../functions.php:664 ../functions.php:679
-#: ../functions.php:689
+#: ../functions.php:663 ../functions.php:672 ../functions.php:687
+#: ../functions.php:697
 msgid "Permanent link to this comment by "
 msgstr ""
 
-#: ../functions.php:658 ../functions.php:667 ../functions.php:682
-#: ../functions.php:692
+#: ../functions.php:666 ../functions.php:675 ../functions.php:690
+#: ../functions.php:700
 #, php-format
 msgid "%1$s at %2$s"
 msgstr ""
 
-#: ../functions.php:661
+#: ../functions.php:669
 msgid "Pingback from "
 msgstr ""
 
-#: ../functions.php:678 ../functions.php:688
+#: ../functions.php:686 ../functions.php:696
 msgid "wrote on"
 msgstr ""
 
-#: ../functions.php:698
+#: ../functions.php:706
 msgid "Your comment is awaiting moderation."
 msgstr ""
 
-#: ../functions.php:706
+#: ../functions.php:714
 msgid "Edit Comment"
 msgstr ""
 
-#: ../functions.php:723
+#: ../functions.php:731
 msgid "This widget shows the three most recent featured posts."
 msgstr ""
 
-#: ../functions.php:735
+#: ../functions.php:743
 msgid "Title:"
 msgstr ""
 
-#: ../header.php:49
+#: ../header.php:60
 #, php-format
 msgid "Search results for “%s”"
 msgstr ""
 
-#: ../header.php:53
+#: ../header.php:64
 msgid "Not Found"
 msgstr ""
 
-#: ../header.php:65
+#: ../header.php:76
 msgid "Skip to main content"
 msgstr ""
 
-#: ../header.php:66
+#: ../header.php:77
 msgid "Skip to sidebar"
 msgstr ""
 
-#: ../header.php:68
+#: ../header.php:79
 msgid "Skip to blog search"
 msgstr ""
 

--- a/themes/OneMozilla/style.css
+++ b/themes/OneMozilla/style.css
@@ -623,36 +623,25 @@ html[dir='rtl'] #tabzilla {
   right: 0;
 }
 
+.post .entry-info {
+  clear: both;
+  overflow: hidden;
+  margin-left: -92px;
+}
+
 /*** Post @Author */
 .entry-header .vcard {
-  background: #fff;
-  background: -moz-linear-gradient(left, rgba(255,255,255,0.75) 0%, rgba(255,255,255,0.75) 10%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.75) 90%, rgba(255,255,255,0.75) 100%);
-  background: -o-linear-gradient(left, rgba(255,255,255,0.75) 0%, rgba(255,255,255,0.75) 10%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.75) 90%, rgba(255,255,255,0.75) 100%);
-  background: -webkit-linear-gradient(left, rgba(255,255,255,0.75) 0%, rgba(255,255,255,0.75) 10%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.75) 90%, rgba(255,255,255,0.75) 100%);
-  background: linear-gradient(left, rgba(255,255,255,0.75) 0%, rgba(255,255,255,0.75) 10%, rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.75) 90%, rgba(255,255,255,0.75) 100%);
-  border: 1px solid #fff;
-  float: left;
-  font: 1em/1 "Open Sans Light", sans-serif;
-  margin: 0 0 10px -92px;
-  -ms-box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  -o-box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  padding: 15px 20px 15px 65px;
-  position: relative;
-  width: 415px;
-}
-.no-comments .entry-header .vcard {
-  width: 530px;
+  font-size: 16px;
+  margin: .75em 0 .25em;
+  clear: right;
 }
 .entry-header cite {
   font-style: normal;
 }
 .entry-header .vcard img {
   border: 1px solid #fff;
-  left: 0;
-  left: 20px;
-  position: absolute;
-  top: .75em;
+  float: left;
+  margin-right: 10px;
 }
 .entry-header .vcard a:hover img,
 .entry-header .vcard a:focus img,
@@ -662,43 +651,25 @@ html[dir='rtl'] #tabzilla {
 
 /*** Comment Count */
 .entry-comments {
-  background: #fff;
-  float: right;
-  font: 1em/1 "Open Sans Light", sans-serif;
-  margin: 0 0 10px;
-  -ms-box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  -o-box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  width: 100px;
+  clear: left;
+  margin: .75em 0;
 }
 .entry-comments a {
-  background: transparent url("img/icn-comment.png") 24px 17px no-repeat;
-  border: 1px solid #fff;
-  display: block;
-  padding: 15px 5px 15px 47px;
+  display: inline-block;
+  background: url("img/icn-comment.png") 0 .35em no-repeat;
+  padding-left: 35px;
 }
-.entry-comments a:hover,
-.entry-comments a:focus,
-.entry-comments a:active {
-  background-position: 24px -83px;
-}
-.show-comments.no-author .entry-comments {
-  position: absolute;
-  right: 0;
-  top: 0;
-}
+
 
 /*** @Edit buttons */
 .edit {
   font-size: .857em;
 }
 .entry-header .edit {
-  float: left;
   clear: both;
-  margin-left: -92px;
-}
-.page .entry-header .edit {
-  margin: 1.35em 0 .5em;
+  float: right;
+  margin: 1em 0;
+  text-align: right;
 }
 .edit a {
   display: inline-block;
@@ -1122,15 +1093,14 @@ input:-moz-placeholder {
   clear: both;
   margin: 48px 0 24px;
 }
-#comment-list {
+.comment-list {
   list-style: none;
   margin: 0 0 48px;
   padding: 0;
 }
-#comment-list .comment,
-#comment-list .pingback,
-#comment-list .trackback {
-  font-size: .875em;
+.comment-list .comment,
+.comment-list .pingback,
+.comment-list .trackback {
   padding: 19px;
   margin: 0 0 24px;
   background: #fff;
@@ -1140,60 +1110,62 @@ input:-moz-placeholder {
   -ms-box-shadow: 0 1px 1px rgba(0,0,0,0.1);
   box-shadow: 0 1px 1px rgba(0,0,0,0.1);
 }
-#comment-list .alt {
+.comment-list .alt {
   background: #f7f7f7;
   -o-box-shadow: inset 0 1px 3px rgba(0,0,0,.05), 0 1px 1px rgba(0,0,0,0.1);
   -ms-box-shadow: inset 0 1px 3px rgba(0,0,0,.05), 0 1px 1px rgba(0,0,0,0.1);
   box-shadow: inset 0 1px 3px rgba(0,0,0,.05), 0 1px 1px rgba(0,0,0,0.1);
 }
-#comment-list .byuser {
+.comment-list .byuser {
   border-color: #cdd3dc;
   -o-box-shadow: inset 0 2px 12px rgba(175,38,38,.01), 0 1px 1px rgba(0,0,0,0.1);
   -ms-box-shadow: inset 0 2px 12px rgba(175,38,38,.01), 0 1px 1px rgba(0,0,0,0.1);
   box-shadow: inset 0 2px 12px rgba(175,38,38,.01), 0 1px 1px rgba(0,0,0,0.1);
 }
 
-#comment-list.av .comment {
+.comment-list.av .comment,
+#comments.comments-area .comment {
   min-height: 70px;
   padding-left: 92px;
   position: relative;
 }
-#comment-list .entry-title {
+.comment-list .entry-title {
   font-size: 1.25em;
   letter-spacing: normal;
   margin: 0 0 1.5em;
   min-height: 0;
 }
-#comment-list .author {
+.comment-list .author {
   font-style: normal;
 }
-#comment-list .entry-title cite {
+.comment-list .entry-title cite {
   font-style: normal;
 }
-#comment-list .comment-meta {
+.comment-list .comment-meta {
   font-size: .857em;
+  margin: 0 0 1em;
 }
-#comment-list .avatar {
+.comment-list .avatar {
   border: 1px solid #fff;
   box-shadow: 0 1px 1px rgba(0,0,0,.1);
-  left: 19px;
   -moz-transition: all .1s linear;
   -webkit-transition: all .1s linear;
   transition: all .1s linear;
   position: absolute;
-  top: 19px;
+  top: 9px;
+  left: 9px;
 }
-#comment-list a:hover .avatar,
-#comment-list a:focus .avatar,
-#comment-list a:active .avatar {
+.comment-list a:hover .avatar,
+.comment-list a:focus .avatar,
+.comment-list a:active .avatar {
   border-color: inherit;
 }
-#comment-list .entry-content p,
-#comment-list .entry-content pre,
-#comment-list .entry-content blockquote {
+.comment-list .entry-content p,
+.comment-list .entry-content pre,
+.comment-list .entry-content blockquote {
   margin: .75em 0 0;
 }
-#comment-list .mod {
+.comment-list .mod {
   background: #fff2db;
   border: 1px solid #f0dfc0;
   color: #3c3c3c;
@@ -1202,27 +1174,27 @@ input:-moz-placeholder {
   padding: .5em 15px;
   text-align: center;
 }
-#comment-list .comment-util {
+.comment-list .comment-util {
   font-size: 1em;
   margin: 1em 0 0;
   padding: .5em 0 0;
   border-top: 1px dotted rgba(100,100,100,.2);
 }
-#comment-list .comment-util a {
+.comment-list .comment-util a {
   margin-right: 20px;
 }
-#comment-list .comment-reply-link:after {
+.comment-list .comment-reply-link:after {
   content: "\00A0\00BB"; /* nbsp raquo */
   font-size: 1.2em;
 }
-#comment-list .comment-util .edit {
+.comment-list .comment-util .edit {
   font-size: 1em;
 }
-#comment-list ol.children {
+.comment-list ol.children {
   list-style: none;
   margin: 24px 0 0;
 }
-#comment-list ol.children .comment {
+.comment-list ol.children .comment {
   font-size: 1em;
   margin: 0 0 0 -72px;
 }


### PR DESCRIPTION
Discourse comments use their own template that doesn't quite mesh with the theme's custom template. This change updates the theme to play well with Discourse comments and also simplifies post headers (which will also pay off when I add support for co-authors in a separate commit).