### PR TITLE
Avoid duplicated mozilla-wordmark og:image for single posts

### DIFF
--- a/themes/OneMozilla/header.php
+++ b/themes/OneMozilla/header.php
@@ -20,8 +20,6 @@
   <?php if (has_post_thumbnail()) : ?>
   <?php $thumb = wp_get_attachment_image_src( get_post_thumbnail_id($post->ID), 'medium' ); ?>
     <meta property="og:image" content="<?php echo $thumb['0']; ?>">
-  <?php else : ?>
-    <meta property="og:image" content="<?php echo get_template_directory_uri(); ?>/img/mozilla-wordmark.png">
   <?php endif; ?>
 <?php elseif (get_header_image()) : ?>
   <meta property="og:image" content="<?php echo get_header_image(); ?>">


### PR DESCRIPTION
The mozilla-wordmark.png is added in all cases, so no need to add it conditionally for single posts at all.