### PR TITLE
Ensure loading after jQuery

### DIFF
--- a/themes/OneMozilla/functions.php
+++ b/themes/OneMozilla/functions.php
@@ -386,7 +386,7 @@ function onemozilla_load_scripts() {
   wp_enqueue_script('jquery');
 
   // Register and load the socialsharing script
-  wp_register_script( 'socialshare', get_template_directory_uri() . '/js/socialshare.min.js' );
+  wp_register_script( 'socialshare', get_template_directory_uri() . '/js/socialshare.min.js', array( 'jquery' ) );
   if ( (get_option('onemozilla_share_posts') == 1 || get_option('onemozilla_share_pages') == 1) && is_singular() ) {
     wp_enqueue_script( 'socialshare' );
   }
@@ -397,7 +397,7 @@ function onemozilla_load_scripts() {
   }
 
   // Check required fields on comment form
-  wp_register_script( 'checkcomments', get_template_directory_uri() . '/js/fc-checkcomment.js' );
+  wp_register_script( 'checkcomments', get_template_directory_uri() . '/js/fc-checkcomment.js', array( 'jquery' ) );
   if ( get_option('require_name_email') && is_singular() ) {
     wp_enqueue_script('checkcomments');
     wp_localize_script('checkcomments', 'objectL10n', array(


### PR DESCRIPTION
I have rebased the second commit from #61 on master. I think it is worth to merge this one to ensure scripts using jQuery are loaded after it. Currently it can happen in wrong order resulting in comments check or social share button not working.

@craigcook r?